### PR TITLE
Remove Aero mission director app

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,6 @@ layout: index
 	The Columbia Space Initiative is a group of students and professors dedicated to the pursuit of knowledge in near-space, space, and beyond.
     </small></h2>
 
-    <div class="alert alert-info">
-     <strong>Fall 2017: </strong> Apply for Digital Twin Design Challenge mission director <a href="https://docs.google.com/forms/d/e/1FAIpQLScO2KIrBUyR8JQoF22WP9ZJnwIeK__0uwelsdsvyohABHfuUQ/viewform" class="alert-link"> HERE</a>. Details on the challenge <a href="https://aero.larc.nasa.gov/files/2012/11/Digital-Twin-Design-Challenge-2017-2018.pdf" class="alert-link">HERE</a>.
-   </div>
-
   </div>
 </div>
 


### PR DESCRIPTION
Remove link for aero twin design application. Mission directors have been selected