### PR TITLE
Add mission leader emails

### DIFF
--- a/_includes/mission.html
+++ b/_includes/mission.html
@@ -143,6 +143,7 @@
 {% assign rolelist = page.leaderrole | split: ';' %}
 {% assign schoollist = page.leaderschool | split: ';' %}
 {% assign majorlist = page.leadermajor | split: ';' %}
+{% assign emaillist = page.leaderemail | split: ';' %}
 {% assign profimglist = page.leaderimage | split: ';' %}
 
 {% for aleader in leaderslist %}
@@ -169,6 +170,7 @@
 					<h3><small>{{ rolelist[forloop.index0] }}</small></h3>
 					<h3><small>{{ schoollist[forloop.index0] }}</small></h3>
 					<h3><small>{{ majorlist[forloop.index0] }}</small></h3>
+					<h3><small><a href="mailto:{{ emaillist[forloop.index0] }}">{{ emaillist[forloop.index0] }}</a></small></h3>
 				</div>
 				<div class="col-md-1"></div>
 			</div>

--- a/missions/mission-blue-origin.html
+++ b/missions/mission-blue-origin.html
@@ -26,6 +26,7 @@ missionleader: "Sabrina Gjerswold-Selleck; Chris Mendell Jr.;Nathalie Hager; Luk
 leaderrole: "Mission Lead; Mission Lead;Senior Advisor; Senior Advisor"
 leaderschool: "SEAS 2021; GS 2023; SEAS 2021; SEAS 2021"
 leadermajor: "Biomedical Engineering; Neuroscience & Behavior; Computer Science; Mechanical Engineering"
+leaderemail: "sg3459@columbia.edu;;;"
 leaderimage: "/assets/media/img/profiles2019/sgjerswold-selleck.jpg;/assets/media/img/profiles2019/cmendell.jpg;/assets/media/img/profiles2018/nhager.jpeg; /assets/media/img/profiles2017/ldcruz.jpg"
 
 news: true

--- a/missions/mission-outreach-operations.html
+++ b/missions/mission-outreach-operations.html
@@ -24,6 +24,7 @@ missionleader: "Hugo Favila; Khadija Hanif"
 leaderrole: "Outreach Director; Operations Director"
 leaderschool: "SEAS 2021; Barnard 2022"
 leadermajor: "Mechanical Engineering; Applied Physics"
+leaderemail: "hif2105@columbia.edu;"
 leaderimage: "
 /assets/media/img/profiles2020/hfavila.jpg;
 /assets/media/img/profiles2019/khanif.jpg

--- a/missions/mission-rockets.html
+++ b/missions/mission-rockets.html
@@ -26,6 +26,7 @@ achievementstext: ""
 missionleader: "Daniel Kolano"
 leaderschool: "SEAS 2021;"
 leadermajor: "Mechanical Engineering;"
+leaderemail: "dwk2117@columbia.edu;"
 leaderimage: "/assets/media/img/profiles2019/dkolano.jpg;"
 
 news: false

--- a/missions/mission-spocs.html
+++ b/missions/mission-spocs.html
@@ -32,6 +32,7 @@ achievementstext: ""
 missionleader: "Kalpana Ganeshan; Swati Ravi"
 leaderschool: "SEAS 2022; CC 2022"
 leadermajor: "Operations Research; Physics"
+leaderemail: "kg2712@columbia.edu;"
 leaderimage: "
 /assets/media/img/profiles2020/kganeshan.jpg;
 /assets/media/img/profiles2019/sravi.jpg


### PR DESCRIPTION
Modify `_includes/mission.html` to include a `leaderemail` field to be displayed below the leader's major.

Added some provided emails to mission pages.